### PR TITLE
[PKG-6898] 3.16.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,11 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Integrate PostHog into any python application
+  description: |
+    Integrate PostHog into any python application
+  dev_url: https://github.com/PostHog/posthog-python
+  doc_url: https://posthog.com/docs/libraries/python
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "posthog" %}
-{% set version = "2.2.0" %}
+{% set version = "3.16.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,32 +7,42 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1f450a20f7bed217874ded234f6ffc24ae73da37a16aa5bf76335249b34a9f60
+  sha256: 953176a443b30b1404c0f36010a95caad60a83c31ecb17b427f6d986f6f765c1
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7.0,<4.0.0
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7.0,<4.0.0
+    - python
     - requests >=2.7.0,<3.0.0
-    - six >=1.5.0,<2.0.0
-    - monotonic >=1.5.0,<2.0.0
-    - backoff >=1.10.0,<2.0.0
-    - python-dateutil >=2.1.0,<3.0.0
+    - six >=1.5.0
+    - monotonic >=1.5.0
+    - backoff >=1.10.0
+    - python-dateutil >=2.1.0
+    - distro >=1.5.0
 
 test:
   imports:
     - posthog
   requires:
+    - freezegun =1.5.1
+    - mock >=2.0.0
     - pip
+    - pytest
+    - pytest-timeout
+    - pytest-asyncio
+    - parameterized >=0.8.1
+    - pydantic
   commands:
     - pip check
+    - pytest --pyargs posthog.test -k "not test_basic_capture_exception_with_no_exception_given"
 
 about:
   home: https://github.com/PostHog/posthog-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - six >=1.5.0
     - monotonic >=1.5.0
     - backoff >=1.10.0
-    - python-dateutil >=2.1.0
+    - python-dateutil >2.1.0
     - distro >=1.5.0
 
 test:


### PR DESCRIPTION
posthog 3.16.0

**Destination channel:** defaults

### Links

- [PKG-6898]
- [Upstream repository](https://github.com/PostHog/posthog-python)

### Explanation of changes:

- Added upstream tests
  - Unclear why `test_basic_capture_exception_with_no_exception_given` fails, but it seems benign.
- Updated from conda-forge conventions.


[PKG-6898]: https://anaconda.atlassian.net/browse/PKG-6898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ